### PR TITLE
Also fetch html_url when getting issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ spring-social-core/src/test/java/exploration
 **/bin
 .idea
 *.iml
+*.ipr
+*.iws
+out

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubIssue.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubIssue.java
@@ -15,6 +15,7 @@ import java.util.Date;
 public class GitHubIssue {
 	private String number;
 	private String url;
+	private String htmlUrl;
 	private String state;
 	private String title;
 	private String body;
@@ -37,6 +38,15 @@ public class GitHubIssue {
 
 	public void setUrl(String url) {
 		this.url = url;
+	}
+
+	@JsonProperty("html_url")
+	public String getHtmlUrl() {
+		return htmlUrl;
+	}
+
+	public void setHtmlUrl(String htmlUrl) {
+		this.htmlUrl = htmlUrl;
 	}
 
 	public String getState() {

--- a/spring-social-github/src/test/java/org/springframework/social/github/api/impl/RepoTemplateTest.java
+++ b/spring-social-github/src/test/java/org/springframework/social/github/api/impl/RepoTemplateTest.java
@@ -116,6 +116,10 @@ public class RepoTemplateTest extends AbstractGitHubApiTest {
 		assertEquals("Use WAR packaging for rest service", issues.get(0).getTitle());
 		assertEquals("You can deploy to WTP, build a war, execute it (java -jar) or use mvn exec.",
 				issues.get(0).getBody());
+		assertEquals("https://api.github.com/repos/spring-guides/gs-rest-service/issues/10",
+				issues.get(0).getUrl());
+		assertEquals("https://github.com/spring-guides/gs-rest-service/pull/10",
+				issues.get(0).getHtmlUrl());
 	}
 
 	@Test


### PR DESCRIPTION
It currently fetches the API version of the RESTful URL. It's also handy to grab the HTML version of that (found at html_url).
