### PR TITLE
Ignore files created by ./gradlew idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ spring-social-core/src/test/java/exploration
 **/bin
 .idea
 *.iml
+out
+spring-social-github.ipr
+spring-social-github.iws


### PR DESCRIPTION
Ignore the `.ipr` and `.iws` files that are generated by `./gradlew idea` and ignore the `out` directory that's configured as the IDEA modules' output path.
