### PR TITLE
[SOCIALGH-3] Use mixins for JSON mapping

### DIFF
--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubComment.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2012 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,41 +25,56 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * A GitHub comment.
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubComment implements Serializable {
-	private Long id;
-	private String url;
-	private String body;
-	private GitHubUser user;
-	private Date createdAt;
-	private Date updatedAt;
-	
-	public Long getId() { return id; }
-	
-	public void setId(Long id) { this.id = id; }
-	
-	public String getUrl() { return url; }
-	
-	public void setUrl(String url) { this.url = url; }
-	
-	public String getBody() { return body; }
-	
-	public void setBody(String body) { this.body = body; }
-	
-	public GitHubUser getUser() { return user; }
-	
-	public void setUser(GitHubUser user) { this.user = user; }
-	
-	@JsonProperty("created_at")
-	public Date getCreatedAt() { return createdAt; }
-	
-	public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
-	
-	@JsonProperty("updated_at")
-	public Date getUpdatedAt() { return updatedAt; }
-	
-	public void setUpdatedA(Date updatedAt) { this.updatedAt = updatedAt; }
-	
+
+    private final long id;
+
+    private final String url;
+
+    private final GitHubUser user;
+
+    private final Date createdAt;
+
+    private final Date updatedAt;
+
+    private volatile String body;
+
+    public GitHubComment(long id, String url, GitHubUser user, Date createdAt, Date updatedAt) {
+        this.id = id;
+        this.url = url;
+        this.user = user;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public GitHubUser getUser() {
+        return user;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubCommit.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubCommit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,50 +25,44 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * @author Willie Wheeler (willie.wheeler@gmail.com)
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubCommit implements Serializable {
-	private String message;
-	private String sha;
-	private String url;
-	private GitHubUser committer;
-	private GitHubUser author;
-	private GitHubCommit commit;
-	
-	/**
+
+	private final String message;
+
+	private final String sha;
+
+	private final String url;
+
+	private final GitHubUser committer;
+
+	private final GitHubUser author;
+
+    public GitHubCommit(String message, String sha, String url, GitHubUser committer, GitHubUser author) {
+        this.message = message;
+        this.sha = sha;
+        this.url = url;
+        this.committer = committer;
+        this.author = author;
+    }
+
+    /**
 	 * @return commit message
 	 */
 	public String getMessage() { return message; }
-	
-	/**
-	 * @param message commit message
-	 */
-	public void setMessage(String message) { this.message = message; }
-	
+
 	public String getSha() { return sha; }
-	
-	public void setSha(String sha) { this.sha = sha; }
-	
+
 	public String getUrl() { return url; }
-	
-	public void setUrl(String url) { this.url = url; }
-	
+
 	/**
 	 * @return user who committed the patch, perhaps on behalf of a separate
 	 *         author (e.g., Willie authors code, issues a pull request, and
 	 *         Craig commits it)
 	 */
 	public GitHubUser getCommitter() { return committer; }
-	
-	public void setCommitter(GitHubUser committer) { this.committer = committer; }
-	
-	public GitHubUser getAuthor() { return author; }
-	
-	/**
-	 * @param author user who wrote the patch
-	 */
-	public void setAuthor(GitHubUser author) { this.author = author; }
-	
-	public GitHubCommit getCommit() { return commit; }
-	
-	public void setCommit(GitHubCommit commit) { this.commit = commit; }
+
+    /**
+     * @return user who wrote the patch
+     */
+    public GitHubUser getAuthor() { return author; }
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubDownload.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubDownload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2012 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,58 +25,52 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * A GitHub download.
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubDownload implements Serializable {
-	private Long id;
-	private String url;
-	private String htmlUrl;
-	private String name;
-	private String description;
-	private Long size;
-	private Integer downloadCount;
-	private String contentType;
-	private Date createdAt;
 
-	public Long getId() { return id; }
+	private final long id;
 
-	public void setId(Long id) { this.id = id; }
+	private final String url;
+
+	private final String htmlUrl;
+
+	private final String name;
+
+	private final String description;
+
+	private final long size;
+
+	private final int downloadCount;
+
+	private final String contentType;
+
+    public GitHubDownload(long id, String url, String htmlUrl, String name, String description, long size,
+            int downloadCount, String contentType) {
+        this.id = id;
+        this.url = url;
+        this.htmlUrl = htmlUrl;
+        this.name = name;
+        this.description = description;
+        this.size = size;
+        this.downloadCount = downloadCount;
+        this.contentType = contentType;
+    }
+
+    public long getId() { return id; }
 
 	public String getUrl() { return url; }
 
-	public void setUrl(String url) { this.url = url; }
-	
-	@JsonProperty("html_url")
 	public String getHtmlUrl() { return htmlUrl; }
-
-	public void setHtmlUrl(String htmlUrl) { this.htmlUrl = htmlUrl; }
 
 	public String getName() { return name; }
 
-	public void setName(String name) { this.name = name; }
-
 	public String getDescription() { return description; }
 
-	public void setDescription(String description) { this.description = description; }
+	public long getSize() { return size; }
 
-	public Long getSize() { return size; }
+	public int getDownloadCount() { return downloadCount; }
 
-	public void setSize(Long size) { this.size = size; }
-	
-	@JsonProperty("download_count")
-	public Integer getDownloadCount() { return downloadCount; }
-
-	public void setDownloadCount(Integer downloadCount) { this.downloadCount = downloadCount; }
-	
-	@JsonProperty("content_type")
 	public String getContentType() { return contentType; }
-
-	public void setContentType(String contentType) { this.contentType = contentType; }
-	
-	@JsonProperty("created_at")
-	public Date getCreatedAt() { return createdAt; }
-	
-	public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
-	
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubFile.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2012 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,40 +24,43 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * A GitHub file.
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubFile implements Serializable {
-	private String filename;
-	private String type;
-	private String language;
-	private String rawUrl;
-	private Long size;
-	private String content;
 
-	public String getFilename() { return filename; }
+    private final String type;
+
+    private final String language;
+
+    private final String rawUrl;
+
+    private final long size;
+
+    private String filename;
+
+    private String content;
+
+    public GitHubFile(String type, String language, String rawUrl, long size) {
+        this.type = type;
+        this.language = language;
+        this.rawUrl = rawUrl;
+        this.size = size;
+    }
+
+    public String getType() { return type; }
+
+    public String getLanguage() { return language; }
+
+    public String getRawUrl() { return rawUrl; }
+
+    public long getSize() { return size; }
+
+    public String getFilename() { return filename; }
 
 	public void setFilename(String filename) { this.filename = filename; }
-
-	public String getType() { return type; }
-
-	public void setType(String type) { this.type = type; }
-
-	public String getLanguage() { return language; }
-
-	public void setLanguage(String language) { this.language = language; }
-	
-	@JsonProperty("raw_url")
-	public String getRawUrl() { return rawUrl; }
-
-	public void setRawUrl(String rawUrl) { this.rawUrl = rawUrl; }
-
-	public Long getSize() { return size; }
-
-	public void setSize(Long size) { this.size = size; }
 
 	public String getContent() { return content; }
 
 	public void setContent(String content) { this.content = content; }
-
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubGist.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubGist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2012 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,31 +26,52 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * A GitHub gist.
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubGist implements Serializable {
-	private String id;
-	private String url;
-	private String description;
-	private boolean publicGist;
-	private GitHubUser user;
-	private Map<String, GitHubFile> files;
-	private Integer comments;
-	private String htmlUrl;
-	private String gitPullUrl;
-	private String gitPushUrl;
-	private Date createdAt;
-	private Date updatedAt;
-	
-	// Looks like GitHub is returning a string, even though the IDs appear to be stringified integers.
+
+	private final String id;
+
+	private final String url;
+
+	private final boolean publicGist;
+
+	private final GitHubUser user;
+
+	private final int comments;
+
+	private final String htmlUrl;
+
+    private final String gitPullUrl;
+
+	private final String gitPushUrl;
+
+	private final Date createdAt;
+
+	private final Date updatedAt;
+
+    private String description;
+
+    private Map<String, GitHubFile> files;
+
+    public GitHubGist(String id, String url, boolean publicGist, GitHubUser user, int comments, String htmlUrl,
+            String gitPullUrl, String gitPushUrl, Date createdAt, Date updatedAt) {
+        this.id = id;
+        this.url = url;
+        this.publicGist = publicGist;
+        this.user = user;
+        this.comments = comments;
+        this.htmlUrl = htmlUrl;
+        this.gitPullUrl = gitPullUrl;
+        this.gitPushUrl = gitPushUrl;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
 	public String getId() { return id; }
 	
-	public void setId(String id) { this.id = id; }
-	
 	public String getUrl() { return url; }
-	
-	public void setUrl(String url) { this.url = url; }
 	
 	public String getDescription() { return description; }
 	
@@ -58,43 +79,21 @@ public class GitHubGist implements Serializable {
 	
 	public boolean isPublic() { return publicGist; }
 	
-	public void setPublic(boolean publicGist) { this.publicGist = publicGist; }
-	
 	public GitHubUser getUser() { return user; }
-	
-	public void setUser(GitHubUser user) { this.user = user; }
 	
 	public Map<String, GitHubFile> getFiles() { return files; }
 	
 	public void setFiles(Map<String, GitHubFile> files) { this.files = files; }
 	
-	public Integer getComments() { return comments; }
-	
-	public void setComments(Integer comments) { this.comments = comments; }
-	
-	@JsonProperty("html_url")
+	public int getComments() { return comments; }
+
 	public String getHtmlUrl() { return htmlUrl; }
-	
-	public void setHtmlUrl(String htmlUrl) { this.htmlUrl = htmlUrl; }
-	
-	@JsonProperty("git_pull_url")
+
 	public String getGitPullUrl() { return gitPullUrl; }
-	
-	public void setGitPullUrl(String gitPullUrl) { this.gitPullUrl = gitPullUrl; }
-	
-	@JsonProperty("git_push_url")
+
 	public String getGitPushUrl() { return gitPushUrl; }
-	
-	public void setGitPushUrl(String gitPushUrl) { this.gitPushUrl = gitPushUrl; }
-	
-	@JsonProperty("created_at")
+
 	public Date getCreatedAt() { return createdAt; }
-	
-	public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
-	
-	@JsonProperty("updated_at")
+
 	public Date getUpdatedAt() { return updatedAt; }
-	
-	public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
-	
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubHook.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2012 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,41 +25,46 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * A GitHub hook. Hooks share commits with other apps, such as Bamboo, Basecamp, e-mail and so forth.
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubHook implements Serializable {
-	private Long id;
-	private String name;
-	private String url;
+
+	private final long id;
+
+	private final String name;
+
+	private final String url;
+
+    private final Date createdAt;
+
+    private final Date updatedAt;
+
 	private boolean active;
-	private Date createdAt;
-	private Date updatedAt;
-	
-	public Long getId() { return id; }
-	
-	public void setId(Long id) { this.id = id; }
+
+    public GitHubHook(long id, String name, String url, Date createdAt, Date updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.url = url;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public long getId() { return id; }
 	
 	public String getName() { return name; }
 	
-	public void setName(String name) { this.name = name; }
-	
 	public String getUrl() { return url; }
-	
-	public void setUrl(String url) { this.url = url; }
-	
-	public boolean getActive() { return active; }
-	
-	public void setActive(boolean active) { this.active = active; }
-	
-	@JsonProperty("created_at")
-	public Date getCreatedAt() { return createdAt; }
-	
-	public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
-	
-	@JsonProperty("updated_at")
-	public Date getUpdatedAt() { return updatedAt; }
-	
-	public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
 
+	public Date getCreatedAt() { return createdAt; }
+
+	public Date getUpdatedAt() { return updatedAt; }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubIssue.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubIssue.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.social.github.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -9,35 +24,56 @@ import java.util.Date;
  * A GitHub issue
  *
  * @author Greg Turnquist
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubIssue {
-	private String number;
-	private String url;
+
+	private final int number;
+
+	private final String url;
+
+    private final Date closedAt;
+
+    private final Date createdAt;
+
+    private final Date updatedAt;
+
 	private String state;
+
 	private String title;
+
 	private String body;
+
 	private GitHubUser assignee;
-	private Date closedAt;
-	private Date createdAt;
-	private Date updatedAt;
 
-	public String getNumber() {
+    public GitHubIssue(int number, String url, Date closedAt, Date createdAt, Date updatedAt) {
+        this.number = number;
+        this.url = url;
+        this.closedAt = closedAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public int getNumber() {
 		return number;
-	}
-
-	public void setNumber(String number) {
-		this.number = number;
 	}
 
 	public String getUrl() {
 		return url;
 	}
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
+    public Date getClosedAt() {
+        return closedAt;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
 
 	public String getState() {
 		return state;
@@ -69,32 +105,5 @@ public class GitHubIssue {
 
 	public void setAssignee(GitHubUser assignee) {
 		this.assignee = assignee;
-	}
-
-	@JsonProperty("closed_at")
-	public Date getClosedAt() {
-		return closedAt;
-	}
-
-	public void setClosedAt(Date closedAt) {
-		this.closedAt = closedAt;
-	}
-
-	@JsonProperty("created_at")
-	public Date getCreatedAt() {
-		return createdAt;
-	}
-
-	public void setCreatedAt(Date createdAt) {
-		this.createdAt = createdAt;
-	}
-
-	@JsonProperty("updated_at")
-	public Date getUpdatedAt() {
-		return updatedAt;
-	}
-
-	public void setUpdatedAt(Date updatedAt) {
-		this.updatedAt = updatedAt;
 	}
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubRepo.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubRepo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2012 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,59 +24,60 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * A GitHub repo.
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubRepo implements Serializable {
-	private Long id;
-	private String name;
-	private String description;
-	private String url;
-	private String htmlUrl;
-	private String cloneUrl;
-	private String gitUrl;
-	private String sshUrl;
-	private String svnUrl;
+
+	private final long id;
+
+	private final String url;
+
+	private final String htmlUrl;
+
+	private final String cloneUrl;
+
+	private final String gitUrl;
+
+	private final String sshUrl;
+
+	private final String svnUrl;
+
+    public GitHubRepo(long id, String url, String htmlUrl, String cloneUrl, String gitUrl, String sshUrl,
+            String svnUrl) {
+        this.id = id;
+        this.url = url;
+        this.htmlUrl = htmlUrl;
+        this.cloneUrl = cloneUrl;
+        this.gitUrl = gitUrl;
+        this.sshUrl = sshUrl;
+        this.svnUrl = svnUrl;
+    }
+
+    private String name;
+
+    private String description;
 	
-	public Long getId() { return id; }
-	
-	public void setId(Long id) { this.id = id; }
-	
-	public String getName() { return name; }
-	
-	public void setName(String name) { this.name = name; }
-	
-	public String getDescription() { return description; }
-	
-	public void setDescription(String description) { this.description = description; }
+	public long getId() { return id; }
 	
 	public String getUrl() { return url; }
-	
-	public void setUrl(String url) { this.url = url; }
-	
-	@JsonProperty("html_url")
+
 	public String getHtmlUrl() { return htmlUrl; }
-	
-	public void setHtmlUrl(String htmlUrl) { this.htmlUrl = htmlUrl; }
-	
-	@JsonProperty("clone_url")
+
 	public String getCloneUrl() { return cloneUrl; }
-	
-	public void setCloneUrl(String cloneUrl) { this.cloneUrl = cloneUrl; }
-	
-	@JsonProperty("git_url")
+
 	public String getGitUrl() { return gitUrl; }
-	
-	public void setGitUrl(String gitUrl) { this.gitUrl = gitUrl; }
-	
-	@JsonProperty("ssh_url")
+
 	public String getSshUrl() { return sshUrl; }
-	
-	public void setSshUrl(String sshUrl) { this.sshUrl = sshUrl; }
-	
-	@JsonProperty("svn_url")
+
 	public String getSvnUrl() { return svnUrl; }
-	
-	public void setSvnUrl(String svnUrl) { this.svnUrl = svnUrl; }
+
+    public String getName() { return name; }
+
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+
+    public void setDescription(String description) { this.description = description; }
 	
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubUser.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,46 +22,45 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * A GitHub repository user.
+ * A GitHub user
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 @SuppressWarnings("serial")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubUser implements Serializable {
-	private Long id;
-	private String url;
-	private String login;
-	private String avatarUrl;
-	private String gravatarId;
+
+	private final long id;
+
+	private final String url;
+
+	private final String login;
+
+	private final String avatarUrl;
+
+	private final String gravatarId;
+
 	private String name;
+
 	private String email;
-	private Date date;
-	
-	public Long getId() { return id; }
-	
-	public void setId(Long id) { this.id = id; }
+
+    public GitHubUser(long id, String url, String login, String avatarUrl, String gravatarId) {
+        this.id = id;
+        this.url = url;
+        this.login = login;
+        this.avatarUrl = avatarUrl;
+        this.gravatarId = gravatarId;
+    }
+
+    public Long getId() { return id; }
 	
 	public String getUrl() { return url; }
-	
-	public void setUrl(String url) { this.url = url; }
-	
-	/**
-	 * @return watcher's GitHub login
-	 */
+
 	public String getLogin() { return login; }
-	
-	public void setLogin(String login) { this.login = login; }
-	
-	@JsonProperty("avatar_url")
+
 	public String getAvatarUrl() { return avatarUrl; }
-	
-	public void setAvatarUrl(String avatarUrl) { this.avatarUrl = avatarUrl; }
-	
-	@JsonProperty("gravatar_id")
+
 	public String getGravatarId() { return gravatarId; }
-	
-	public void setGravatarId(String gravatarId) { this.gravatarId = gravatarId; }
 	
 	public String getName() { return name; }
 	
@@ -70,8 +69,4 @@ public class GitHubUser implements Serializable {
 	public String getEmail() { return email; }
 	
 	public void setEmail(String email) { this.email = email; }
-	
-	public Date getDate() { return date; }
-	
-	public void setDate(Date date) { this.date = date; }
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubUserProfile.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/GitHubUserProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,65 +18,91 @@ package org.springframework.social.github.api;
 import java.io.Serializable;
 import java.util.Date;
 
+/**
+ * @author Andy Wilkinson
+ */
 public class GitHubUserProfile implements Serializable {
+
 	private static final long serialVersionUID = 1L;
 
 	private final long id;
-	private final String name;
-	private final String username;
-	private final String location;
-	private final String company;
-	private final String blog;
-	private final String email;
-	private final Date createdDate;
-	private final String profileImageUrl;
 
-	public GitHubUserProfile(long id, String username, String name, String location, String company, String blog,
-			String email, String profileImageUrl, Date createdDate) {
-		this.id = id;
-		this.username = username;
-		this.name = name;
-		this.location = location;
-		this.company = company;
-		this.blog = blog;
-		this.email = email;
-		this.profileImageUrl = profileImageUrl;
-		this.createdDate = createdDate;
-	}
+    private final String login;
 
-	public long getId() {
-		return id;
-	}
+    private final String avatarUrl;
 
-	public String getName() {
-		return name;
-	}
+    private final Date createdAt;
 
-	public String getUsername() {
-		return username;
-	}
+	private String name;
 
-	public String getLocation() {
-		return location;
-	}
+	private String location;
 
-	public String getCompany() {
-		return company;
-	}
+	private String company;
 
-	public String getBlog() {
-		return blog;
-	}
+	private String blog;
 
-	public String getEmail() {
-		return email;
-	}
+	private String email;
 
-	public Date getCreatedDate() {
-		return createdDate;
-	}
+    public GitHubUserProfile(long id, String login, String avatarUrl, Date createdAt) {
+        this.id = id;
+        this.login = login;
+        this.avatarUrl = avatarUrl;
+        this.createdAt = createdAt;
+    }
 
-	public String getProfileImageUrl() {
-		return profileImageUrl;
-	}
+    public long getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public void setCompany(String company) {
+        this.company = company;
+    }
+
+    public String getBlog() {
+        return blog;
+    }
+
+    public void setBlog(String blog) {
+        this.blog = blog;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
 }

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/GitHubTemplate.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/GitHubTemplate.java
@@ -15,10 +15,13 @@
  */
 package org.springframework.social.github.api.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.social.github.api.GistOperations;
 import org.springframework.social.github.api.GitHub;
 import org.springframework.social.github.api.RepoOperations;
 import org.springframework.social.github.api.UserOperations;
+import org.springframework.social.github.api.impl.json.GitHubModule;
 import org.springframework.social.oauth2.AbstractOAuth2ApiBinding;
 import org.springframework.social.oauth2.OAuth2Version;
 import org.springframework.web.client.RestOperations;
@@ -29,6 +32,7 @@ import org.springframework.web.client.RestOperations;
  * </p>
  * @author Craig Walls
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 public class GitHubTemplate extends AbstractOAuth2ApiBinding implements GitHub {
 	private GistOperations gistOperations;
@@ -79,8 +83,17 @@ public class GitHubTemplate extends AbstractOAuth2ApiBinding implements GitHub {
 	public RestOperations restOperations() {
 		return getRestTemplate();
 	}
-	
-	// internal helpers
+
+    @Override
+    protected MappingJackson2HttpMessageConverter getJsonMessageConverter() {
+        MappingJackson2HttpMessageConverter converter = super.getJsonMessageConverter();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new GitHubModule());
+        converter.setObjectMapper(objectMapper);
+        return converter;
+    }
+
+    // internal helpers
 	
 	private void initSubApis() {
 		this.gistOperations = new GistTemplate(getRestTemplate(), isAuthorized());

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/UserTemplate.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/UserTemplate.java
@@ -36,29 +36,18 @@ import org.springframework.web.client.RestTemplate;
  * </p>
  * 
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 public class UserTemplate extends AbstractGitHubOperations implements UserOperations {
 
 	private final RestTemplate restTemplate;
 	
 	public String getProfileId() {
-		return getUserProfile().getUsername();
+		return getUserProfile().getLogin();
 	}
 
 	public GitHubUserProfile getUserProfile() {
-		@SuppressWarnings("unchecked")
-		Map<String, ?> user = restTemplate.getForObject(buildUri("user"), Map.class);		
-		Long gitHubId = Long.valueOf(String.valueOf(user.get("id")));
-		String username = String.valueOf(user.get("login"));
-		String name = String.valueOf(user.get("name"));
-		String location = user.get("location") != null ? String.valueOf(user.get("location")) : null;
-		String company = user.get("company") != null ? String.valueOf(user.get("company")) : null;
-		String blog = user.get("blog") != null ? String.valueOf(user.get("blog")) : null;
-		String email = user.get("email") != null ? String.valueOf(user.get("email")) : null;
-		Date createdDate = toDate(String.valueOf(user.get("created_at")), dateFormat);
-		String gravatarId = (String) user.get("gravatar_id");
-		String profileImageUrl = gravatarId != null ? "https://secure.gravatar.com/avatar/" + gravatarId : null;
-		return new GitHubUserProfile(gitHubId, username, name, location, company, blog, email, profileImageUrl, createdDate);
+		return restTemplate.getForObject(buildUri("user"), GitHubUserProfile.class);
 	}
 
 	public String getProfileUrl() {

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubCommentMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubCommentMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubComment;
+import org.springframework.social.github.api.GitHubUser;
+
+import java.util.Date;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubComment}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubCommentMixin extends GitHubObjectMixin {
+
+    @JsonProperty("body")
+    String body;
+
+    @JsonCreator
+    GitHubCommentMixin(
+            @JsonProperty("id") long id,
+            @JsonProperty("url") String url,
+            @JsonProperty("user") GitHubUser user,
+            @JsonProperty("created_at") Date createdAt,
+            @JsonProperty("updated_at") Date updatedAt) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubCommitMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubCommitMixin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubCommit;
+import org.springframework.social.github.api.GitHubUser;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubCommit}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubCommitMixin extends GitHubObjectMixin {
+
+    GitHubCommitMixin(
+            @JsonProperty("message") String message,
+            @JsonProperty("sha") String sha,
+            @JsonProperty("url") String url,
+            @JsonProperty("committer") GitHubUser committer,
+            @JsonProperty("author") GitHubUser author) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubDownloadMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubDownloadMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubDownload;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubDownload}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubDownloadMixin extends GitHubObjectMixin {
+
+    GitHubDownloadMixin(
+        @JsonProperty("id") long id,
+        @JsonProperty("url") String url,
+        @JsonProperty("html_url") String htmlUrl,
+        @JsonProperty("name") String name,
+        @JsonProperty("description") String description,
+        @JsonProperty("size") long size,
+        @JsonProperty("download_count") int downloadCount,
+        @JsonProperty("content_type") String contentType) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubFileMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubFileMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubFile;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubFile}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubFileMixin extends GitHubObjectMixin {
+
+    @JsonProperty("filename")
+    String filename;
+
+    @JsonProperty("content")
+    String content;
+
+    GitHubFileMixin(
+            @JsonProperty("type") String type,
+            @JsonProperty("language") String language,
+            @JsonProperty("raw_url") String rawUrl,
+            @JsonProperty("size") long size) {}
+
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubGistMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubGistMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubFile;
+import org.springframework.social.github.api.GitHubGist;
+import org.springframework.social.github.api.GitHubUser;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubGist}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubGistMixin extends GitHubObjectMixin {
+
+    @JsonProperty("files")
+    Map<String, GitHubFile> files;
+
+    @JsonProperty("description")
+    String description;
+
+    GitHubGistMixin(
+            @JsonProperty("id") String id,
+            @JsonProperty("url") String url,
+            @JsonProperty("public") boolean publicGist,
+            @JsonProperty("user") GitHubUser user,
+            @JsonProperty("comments") int comments,
+            @JsonProperty("html_url") String htmlUrl,
+            @JsonProperty("git_pull_url") String gitPullUrl,
+            @JsonProperty("git_push_url") String gitPushUrl,
+            @JsonProperty("created_at") Date createdAt,
+            @JsonProperty("updated_at") Date updatedAt) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubHookMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubHookMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubHook;
+
+import java.util.Date;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubHook}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubHookMixin extends GitHubObjectMixin {
+
+    @JsonProperty("active")
+    boolean active;
+
+    GitHubHookMixin(
+            @JsonProperty("id") long id,
+            @JsonProperty("name") String name,
+            @JsonProperty("url") String url,
+            @JsonProperty("created_at") Date createdAt,
+            @JsonProperty("updated_at") Date updatedAt) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubIssueMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubIssueMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubIssue;
+import org.springframework.social.github.api.GitHubUser;
+
+import java.util.Date;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubIssue}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubIssueMixin extends GitHubObjectMixin {
+
+    @JsonProperty("state")
+    String state;
+
+    @JsonProperty("title")
+    String title;
+
+    @JsonProperty("body")
+    String body;
+
+    @JsonProperty("assignee")
+    GitHubUser assignee;
+
+    GitHubIssueMixin(
+            @JsonProperty("number") int number,
+            @JsonProperty("url") String url,
+            @JsonProperty("closed_at") Date closedAt,
+            @JsonProperty("created_at") Date createdAt,
+            @JsonProperty("updated_at") Date updatedAt) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubModule.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubModule.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.social.github.api.*;
+
+/**
+ * Jackson module for setting up mixin annotations on GitHub model types.
+ *
+ * @author Andy Wilkinson
+ */
+public class GitHubModule extends SimpleModule {
+
+    public GitHubModule() {
+        super("GitHubModule");
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.setMixInAnnotations(GitHubComment.class, GitHubCommentMixin.class);
+        context.setMixInAnnotations(GitHubCommit.class, GitHubCommitMixin.class);
+        context.setMixInAnnotations(GitHubDownload.class, GitHubDownloadMixin.class);
+        context.setMixInAnnotations(GitHubFile.class, GitHubFileMixin.class);
+        context.setMixInAnnotations(GitHubGist.class, GitHubGistMixin.class);
+        context.setMixInAnnotations(GitHubHook.class, GitHubHookMixin.class);
+        context.setMixInAnnotations(GitHubIssue.class, GitHubIssueMixin.class);
+        context.setMixInAnnotations(GitHubRepo.class, GitHubRepoMixin.class);
+        context.setMixInAnnotations(GitHubUser.class, GitHubUserMixin.class);
+        context.setMixInAnnotations(GitHubUserProfile.class, GitHubUserProfileMixin.class);
+    }
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubObjectMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubObjectMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Annotated mixin to add Jackson annotations to GitHub API objects
+ *
+ * @author Andy Wilkinson
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class GitHubObjectMixin {
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubRepoMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubRepoMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubRepo;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubRepo}
+ *
+ * @author Andy Wilkinson
+ */
+public class GitHubRepoMixin extends GitHubObjectMixin {
+
+    @JsonProperty("name")
+    String name;
+
+    @JsonProperty("description")
+    String description;
+
+    GitHubRepoMixin(
+            @JsonProperty("id") long id,
+            @JsonProperty("url") String url,
+            @JsonProperty("html_url") String htmlUrl,
+            @JsonProperty("clone_url") String clone_url,
+            @JsonProperty("git_url") String gitUrl,
+            @JsonProperty("ssh_url") String sshUrl,
+            @JsonProperty("svn_url") String svnUrl) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubUserMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubUserMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubUser;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubUser}
+ *
+ * @author Andy Wilkinson
+ */
+abstract class GitHubUserMixin extends GitHubObjectMixin {
+
+    String name;
+
+    String email;
+
+    String bio;
+
+    GitHubUserMixin(
+            @JsonProperty("id") long id,
+            @JsonProperty("url") String url,
+            @JsonProperty("login") String login,
+            @JsonProperty("avatar_url") String avatarUrl,
+            @JsonProperty("gravatar_id") String gravatarId) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubUserProfileMixin.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/GitHubUserProfileMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.github.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.social.github.api.GitHubUserProfile;
+
+import java.util.Date;
+
+/**
+ * Annotated mixin to add annotations to {@link GitHubUserProfile}
+ *
+ * @author Andy Wilkinson
+ */
+ abstract class GitHubUserProfileMixin extends GitHubObjectMixin {
+
+    @JsonProperty("name")
+    String name;
+
+    @JsonProperty("location")
+    String location;
+
+    @JsonProperty("company")
+    String company;
+
+    @JsonProperty("blog")
+    String blog;
+
+    @JsonProperty("email")
+    String email;
+
+    GitHubUserProfileMixin(
+            @JsonProperty("id") long id,
+            @JsonProperty("login") String login,
+            @JsonProperty("avatar_url") String avatarUrl,
+            @JsonProperty("created_at") Date createdAt) {}
+}

--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/package-info.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/json/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Jackson mixins for converting GitHub data into API types.
+ */
+package org.springframework.social.github.api.impl.json;

--- a/spring-social-github/src/main/java/org/springframework/social/github/connect/GitHubAdapter.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/connect/GitHubAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.web.client.HttpClientErrorException;
 /**
  * Github ApiAdapter implementation.
  * @author Keith Donald
+ * @author Andy Wilkinson
  */
 public class GitHubAdapter implements ApiAdapter<GitHub> {
 
@@ -42,14 +43,14 @@ public class GitHubAdapter implements ApiAdapter<GitHub> {
 	public void setConnectionValues(GitHub github, ConnectionValues values) {
 		GitHubUserProfile profile = github.userOperations().getUserProfile();
 		values.setProviderUserId(String.valueOf(profile.getId()));		
-		values.setDisplayName(profile.getUsername());
-		values.setProfileUrl("https://github.com/" + profile.getId());
-		values.setImageUrl(profile.getProfileImageUrl());
+		values.setDisplayName(profile.getLogin());
+		values.setProfileUrl("https://github.com/" + profile.getId()); // TODO: Expose and use HTML URL
+		values.setImageUrl(profile.getAvatarUrl());
 	}
 
 	public UserProfile fetchUserProfile(GitHub github) {
 		GitHubUserProfile profile = github.userOperations().getUserProfile();
-		return new UserProfileBuilder().setName(profile.getName()).setEmail(profile.getEmail()).setUsername(profile.getUsername()).build();
+		return new UserProfileBuilder().setName(profile.getName()).setEmail(profile.getEmail()).setUsername(profile.getLogin()).build();
 	}
 	
 	public void updateStatus(GitHub github, String message) {

--- a/spring-social-github/src/test/java/org/springframework/social/github/api/impl/GistTemplateTest.java
+++ b/spring-social-github/src/test/java/org/springframework/social/github/api/impl/GistTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2012 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.social.github.api.GitHubGist;
 
 /**
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 public class GistTemplateTest extends AbstractGitHubApiTest {
 
@@ -46,7 +47,7 @@ public class GistTemplateTest extends AbstractGitHubApiTest {
 		
 		// Verify the gist
 		GitHubGist gist = gists.get(0);
-		assertEquals(0, gist.getComments().intValue());
+		assertEquals(0, gist.getComments());
 		assertTrue(gist.isPublic());
 		assertEquals("https://gist.github.com/1603296", gist.getHtmlUrl());
 		assertEquals("git@gist.github.com:1603296.git", gist.getGitPushUrl());
@@ -61,7 +62,8 @@ public class GistTemplateTest extends AbstractGitHubApiTest {
 		assertEquals("text/plain", file.getType());
 		assertEquals("https://gist.github.com/raw/1603296/18195cefb653c8ed3ecbd0cb3a60a76eb417158e/jmustache-spring-mvc.java", file.getRawUrl());
 		assertEquals("Java", file.getLanguage());
-		assertEquals(3749L, file.getSize().longValue());
+		assertEquals(3749L, file.getSize());
+        assertNull(file.getContent()); // No content for a file in a list of Gists
 	}
 	
 	@Test
@@ -121,7 +123,7 @@ public class GistTemplateTest extends AbstractGitHubApiTest {
 	}
 	
 	private void verifyComment(GitHubComment comment) {
-		assertEquals(77557L, comment.getId().longValue());
+		assertEquals(77557L, comment.getId());
 		assertEquals("https://api.github.com/gists/comments/77557", comment.getUrl());
 		assertEquals("This is a comment.", comment.getBody());
 		assertEquals("williewheeler", comment.getUser().getLogin());

--- a/spring-social-github/src/test/java/org/springframework/social/github/api/impl/UserTemplateTest.java
+++ b/spring-social-github/src/test/java/org/springframework/social/github/api/impl/UserTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.social.github.api.GitHubUserProfile;
 /**
  * @author Craig Walls
  * @author Willie Wheeler (willie.wheeler@gmail.com)
+ * @author Andy Wilkinson
  */
 public class UserTemplateTest extends AbstractGitHubApiTest {
 	
@@ -37,7 +38,7 @@ public class UserTemplateTest extends AbstractGitHubApiTest {
 				.andExpect(header("Authorization", "Bearer ACCESS_TOKEN"))
 				.andRespond(withSuccess(new ClassPathResource("profile.json", getClass()), MediaType.APPLICATION_JSON));
 		GitHubUserProfile profile = gitHub.userOperations().getUserProfile();
-		assertEquals("habuma", profile.getUsername());
+		assertEquals("habuma", profile.getLogin());
 		assertEquals("Craig Walls", profile.getName());
 		assertEquals("SpringSource", profile.getCompany());
 		assertEquals("http://blog.springsource.com/author/cwalls/", profile.getBlog());

--- a/spring-social-github/src/test/java/org/springframework/social/github/api/impl/repo-hooks.json
+++ b/spring-social-github/src/test/java/org/springframework/social/github/api/impl/repo-hooks.json
@@ -1,0 +1,18 @@
+[
+  {
+    "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+    "updated_at": "2011-09-06T20:39:23Z",
+    "created_at": "2011-09-06T17:26:27Z",
+    "name": "web",
+    "events": [
+      "push",
+      "pull_request"
+    ],
+    "active": true,
+    "config": {
+      "url": "http://example.com",
+      "content_type": "json"
+    },
+    "id": 1
+  }
+]

--- a/spring-social-github/src/test/java/org/springframework/social/github/connect/GitHubAdapterTest.java
+++ b/spring-social-github/src/test/java/org/springframework/social/github/connect/GitHubAdapterTest.java
@@ -25,6 +25,8 @@ import org.springframework.social.github.api.GitHub;
 import org.springframework.social.github.api.GitHubUserProfile;
 import org.springframework.social.github.api.UserOperations;
 
+import java.util.Date;
+
 public class GitHubAdapterTest {
 
 	private GitHubAdapter apiAdapter = new GitHubAdapter();
@@ -35,7 +37,7 @@ public class GitHubAdapterTest {
 	public void fetchProfile() {
 		UserOperations userOperations = Mockito.mock(UserOperations.class);
 		when(github.userOperations()).thenReturn(userOperations);
-		when(userOperations.getUserProfile()).thenReturn(new GitHubUserProfile(123456L, "habuma", "Craig Walls", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
+		when(userOperations.getUserProfile()).thenReturn(createProfile(123456L, "habuma", "Craig Walls", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
 		UserProfile profile = apiAdapter.fetchUserProfile(github);
 		assertEquals("Craig Walls", profile.getName());
 		assertEquals("Craig", profile.getFirstName());
@@ -48,7 +50,7 @@ public class GitHubAdapterTest {
 	public void fetchProfileFirstNameOnly() {
 		UserOperations userOperations = Mockito.mock(UserOperations.class);
 		when(github.userOperations()).thenReturn(userOperations);
-		when(userOperations.getUserProfile()).thenReturn(new GitHubUserProfile(123456L, "habuma", "Craig", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
+		when(userOperations.getUserProfile()).thenReturn(createProfile(123456L, "habuma", "Craig", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
 		UserProfile profile = apiAdapter.fetchUserProfile(github);
 		assertEquals("Craig", profile.getName());
 		assertEquals("Craig", profile.getFirstName());
@@ -61,7 +63,7 @@ public class GitHubAdapterTest {
 	public void fetchProfileMiddleName() {
 		UserOperations userOperations = Mockito.mock(UserOperations.class);
 		when(github.userOperations()).thenReturn(userOperations);
-		when(userOperations.getUserProfile()).thenReturn(new GitHubUserProfile(123456L, "habuma", "Michael Craig Walls", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
+		when(userOperations.getUserProfile()).thenReturn(createProfile(123456L, "habuma", "Michael Craig Walls", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
 		UserProfile profile = apiAdapter.fetchUserProfile(github);
 		assertEquals("Michael Craig Walls", profile.getName());
 		assertEquals("Michael", profile.getFirstName());
@@ -74,7 +76,7 @@ public class GitHubAdapterTest {
 	public void fetchProfileExtraWhitespace() {
 		UserOperations userOperations = Mockito.mock(UserOperations.class);
 		when(github.userOperations()).thenReturn(userOperations);
-		when(userOperations.getUserProfile()).thenReturn(new GitHubUserProfile(123456L, "habuma", "Michael    Craig Walls", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
+		when(userOperations.getUserProfile()).thenReturn(createProfile(123456L, "habuma", "Michael    Craig Walls", "Plano, TX", "SpringSource", null, "cwalls@vmware.com", null, null));
 		UserProfile profile = apiAdapter.fetchUserProfile(github);
 		assertEquals("Michael    Craig Walls", profile.getName());
 		assertEquals("Michael", profile.getFirstName());
@@ -82,5 +84,15 @@ public class GitHubAdapterTest {
 		assertEquals("cwalls@vmware.com", profile.getEmail());
 		assertEquals("habuma", profile.getUsername());
 	}
+
+    private GitHubUserProfile createProfile(long id, String login, String name, String location, String company, String blog, String email, String avatarUrl, Date createdAt) {
+        GitHubUserProfile userProfile = new GitHubUserProfile(id, login, avatarUrl, createdAt);
+        userProfile.setBlog(blog);
+        userProfile.setEmail(email);
+        userProfile.setCompany(company);
+        userProfile.setLocation(location);
+        userProfile.setName(name);
+        return userProfile;
+    }
 
 }


### PR DESCRIPTION
As discussed via email with Craig, I plan to contribute some enhancements to the API binding. For example, I'd like to see whether or not a repository's a fork, list a user's organizations, etc. Before I started adding to the binding, I was conscious that by so doing I would be increasing the number of classes and properties that need to be updated to use mixins. Rather than adding to that task, I thought it better to take care of it first, hence this pull request.
