### PR TITLE
[ISSUE-17] - Fix Incorrect profile url calculation.

### DIFF
--- a/spring-social-github/src/main/java/org/springframework/social/github/api/impl/UserTemplate.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/api/impl/UserTemplate.java
@@ -68,7 +68,7 @@ public class UserTemplate extends AbstractGitHubOperations implements UserOperat
 	}
 
 	public String getProfileUrl() {
-		return "https://github.com/" + getProfileId();
+		return "https://github.com/" + getUserProfile().getLogin();
 	}
 
 

--- a/spring-social-github/src/main/java/org/springframework/social/github/connect/GitHubAdapter.java
+++ b/spring-social-github/src/main/java/org/springframework/social/github/connect/GitHubAdapter.java
@@ -44,7 +44,7 @@ public class GitHubAdapter implements ApiAdapter<GitHub> {
 		GitHubUserProfile profile = github.userOperations().getUserProfile();
 		values.setProviderUserId(String.valueOf(profile.getId()));		
 		values.setDisplayName(profile.getLogin());
-		values.setProfileUrl("https://github.com/" + profile.getId()); // TODO: Expose and use HTML URL
+		values.setProfileUrl("https://github.com/" + profile.getLogin()); // TODO: Expose and use HTML URL
 		values.setImageUrl(profile.getAvatarUrl());
 	}
 


### PR DESCRIPTION
UserTemplate#getProfileUrl and GitHubAdapter#ProfileUrl were generating
invalid profile url, because they were using the user_id to generate the
profile url. To generate the correct profile url they must use the
username (login).

Issue link #17 
